### PR TITLE
Update copyright year information

### DIFF
--- a/lib/Genealogy/Relationship.pm
+++ b/lib/Genealogy/Relationship.pm
@@ -260,7 +260,7 @@ perl(1)
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2018, Magnum Solutions Ltd.  All Rights Reserved.
+Copyright (C) 2018-2020, Magnum Solutions Ltd.  All Rights Reserved.
 
 This script is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.


### PR DESCRIPTION
Since the most recent release is from 2020, it makes sense to include
this year in the copyright information.

This PR is submitted in the hope that it is useful. If you want it changed or updated please just let me know and I'll be pleased to resubmit.