### PR TITLE
Ignore automatically generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 Genealogy-Relationship-*.tar.gz
 MYMETA.json
+MYMETA.json.lock
 MYMETA.yml
 Makefile
 blib/
+cover_db/
 pm_to_blib


### PR DESCRIPTION
I noticed when building and testing the dist, that a `MYMETA.json.lock`
file was produced and thought it might be a good idea to ignore this
file so that it doesn't inadvertently get added to the repo.

Also, when running `cover` the `cover_db/` directory is created and this
doesn't need to be in the repo either, hence it's also added to the
ignore list.

If you'd like anything with this patch changed or updated, please just let me know and I'll be happy to fix things and resubmit.