### PR TITLE
Add more test cases

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,8 @@ WriteMakefile(
         List::MoreUtils => 0,
     },
     BUILD_REQUIRES    => {
-        Test::More    => 0,
+        Test::More      => 0,
+	Test::Exception => 0,
     },
     ABSTRACT_FROM     => 'lib/Genealogy/Relationship.pm',
     AUTHOR            => 'Dave Cross <dave@perlhacks.com>',

--- a/t/02-ancestors.t
+++ b/t/02-ancestors.t
@@ -63,6 +63,11 @@ ok($mrca = $rel->most_recent_common_ancestor($father, $son),
 is($mrca->name, 'Father',
   'Got the right most recent common ancestor between father and son');
 
+ok($mrca = $rel->most_recent_common_ancestor($grandfather, $grandfather),
+   'Got a most recent common ancestor between grandfather and grandfather');
+is($mrca->name, 'Grandfather',
+  'A person themself can be their own most recent common ancestor');
+
 is_deeply([$rel->get_relationship_coords($son, $son)], [0, 0],
   'Got right relationship coords between son and himself');
 is_deeply([$rel->get_relationship_coords($son, $grandfather)], [2, 0],

--- a/t/02-ancestors.t
+++ b/t/02-ancestors.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 use FindBin '$Bin';
 use Genealogy::Relationship;
 use lib "$Bin/lib";
@@ -36,6 +37,11 @@ my $cousin = TestPerson->new(
   parent => $uncle,
   gender => 'f',
 );
+my $unrelated_woman = TestPerson->new(
+  id     => 6,
+  name   => 'Unrelated woman',
+  gender => 'f',
+);
 
 my $rel = Genealogy::Relationship->new;
 
@@ -67,6 +73,11 @@ ok($mrca = $rel->most_recent_common_ancestor($grandfather, $grandfather),
    'Got a most recent common ancestor between grandfather and grandfather');
 is($mrca->name, 'Grandfather',
   'A person themself can be their own most recent common ancestor');
+
+throws_ok {
+  $rel->most_recent_common_ancestor( $son, $unrelated_woman )
+} qr/Can't find a common ancestor/,
+  'Unrelated people do not have a common ancestor';
 
 is_deeply([$rel->get_relationship_coords($son, $son)], [0, 0],
   'Got right relationship coords between son and himself');

--- a/t/02-ancestors.t
+++ b/t/02-ancestors.t
@@ -90,6 +90,11 @@ is_deeply([$rel->get_relationship_coords($son, $cousin)], [2, 2],
 is_deeply([$rel->get_relationship_coords($son, $cousin)], [2, 2],
   'Got right relationship coords between cousin and son');
 
+throws_ok {
+  $rel->get_relationship_coords( $son, $unrelated_woman )
+} qr/Can't work out the relationship/,
+  'Unrelated people do not have relationship coordinates';
+
 is($rel->get_relationship($son, $grandfather), 'Grandson',
   'Son is the grandson of the grandfather');
 is($rel->get_relationship($cousin, $grandfather), 'Granddaughter',


### PR DESCRIPTION
The subject of this pull request is fairly bland but that's the basic gist :-)  This PR increases the test coverage to cover three use cases which the code could theoretically run into:

  - a person is compared to themselves to work out if they share a common ancestor
  - a person does not share a common ancestor with an unrelated person
  - a person does not have relationship coordinates if they are compared with an unrelated person

The code coverage before this patch was 95%, which is excellent and hence this patch doesn't really add that much.  Nevertheless, it might help a little bit, hence I thought I'd submit it.

This change also adds a dependency on `Test::Exception`, I hope that's ok.  If not, let me know what you'd like to use instead if you're happy with the idea of testing that the application `die`s where it's supposed to.

As always, if you'd like anything changed, I'll be more than happy to rework and resubmit as required.