### PR TITLE
Indent test code consistently

### DIFF
--- a/t/02-ancestors.t
+++ b/t/02-ancestors.t
@@ -49,17 +49,17 @@ is(@ancestors, 1, 'Father has one ancestor');
 is(@ancestors, 0, 'Grandfather has no ancestors');
 
 ok(my $mrca = $rel->most_recent_common_ancestor($son, $cousin),
-   'Got a most recent common ancestor between son and cousin');
+  'Got a most recent common ancestor between son and cousin');
 is($mrca->name, 'Grandfather',
   'Got the right most recent common ancestor between son and cousin');
 
 ok($mrca = $rel->most_recent_common_ancestor($son, $father),
-   'Got a most recent common ancestor between son and father');
+  'Got a most recent common ancestor between son and father');
 is($mrca->name, 'Father',
   'Got the right most recent common ancestor between son and father');
 
 ok($mrca = $rel->most_recent_common_ancestor($father, $son),
-   'Got a most recent common ancestor between father and son');
+  'Got a most recent common ancestor between father and son');
 is($mrca->name, 'Father',
   'Got the right most recent common ancestor between father and son');
 
@@ -67,8 +67,8 @@ is_deeply([$rel->get_relationship_coords($son, $son)], [0, 0],
   'Got right relationship coords between son and himself');
 is_deeply([$rel->get_relationship_coords($son, $grandfather)], [2, 0],
   'Got right relationship coords between son and grandfather');
-  is_deeply([$rel->get_relationship_coords($grandfather, $son)], [0, 2],
-    'Got right relationship coords between grandfather and son');
+is_deeply([$rel->get_relationship_coords($grandfather, $son)], [0, 2],
+  'Got right relationship coords between grandfather and son');
 is_deeply([$rel->get_relationship_coords($son, $cousin)], [2, 2],
   'Got right relationship coords between son and cousin');
 is_deeply([$rel->get_relationship_coords($son, $cousin)], [2, 2],


### PR DESCRIPTION
Upon reading the tests I noticed that some lines were indented
differently to the others.  This change simply makes the outliers
consistent with the surrounding code and doesn't change any content.

I'd considered using `perltidy` here, but thought that was a bit of overkill.  If you'd like me to reformat the code according to a set `perltidy` style, just let me know and I'd be happy to do it for you :-)